### PR TITLE
feat: Update Board Council year in homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -295,10 +295,10 @@ const eventsImages = [
       <h1
         class={"col-span-full mx-auto w-fit font-outfit text-3xl font-extrabold text-slate-800 lg:text-5xl"}
       >
-        Board Council 2023-24
+        Board Council 2024-25
       </h1>
       <div class={"col-span-full"}>
-        <div class={"grid grid-cols-6 gap-5"}>
+        <div class={"grid grid-cols-7 gap-5"}>
           {TeamData.filter((i) => i.name === "Board Council").flatMap((i) =>
   i.subGroups.flatMap((j) =>
     j.members.map((member) => ({


### PR DESCRIPTION
This commit updates the year in the Board Council heading on the homepage from "2023-24" to "2024-25". The change ensures that the displayed year is accurate and up-to-date.